### PR TITLE
[hotfix] upgrade dependency for windows support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
     "babel-preset-latest": "^6.16.0",
-    "ohm-js": "^0.12.3",
+    "ohm-js": "^0.14.0",
     "webpack": "^1.13.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "json-loader": "^0.5.7",
     "mocha": "^3.1.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,8 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader"},
+      { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" },
+      { test: /\.json$/, loader: 'json-loader' }
     ]
   },
   plugins: [


### PR DESCRIPTION
change log
---
- upgrade ohm-js version from `0.12.3` to `0.14.0`
- add new dependency `json-loader` for webpack build.

related issues
---
see [related ohm-js issue](https://github.com/harc/ohm/issues/205)
